### PR TITLE
fixes logging of tf.Tensors to CSV files

### DIFF
--- a/acme/utils/loggers/csv.py
+++ b/acme/utils/loggers/csv.py
@@ -52,6 +52,7 @@ class CSVLogger(base.Logger):
 
     # Append row to CSV.
     with self._open(self._file_path, mode='a') as f:
+      data = base.to_numpy(data)
       keys = sorted(data.keys())
       writer = csv.DictWriter(f, fieldnames=keys)
       if not self._header_exists:


### PR DESCRIPTION
The issue can be reproduced by running:

```shell
python acme/examples/control_suite/run_d4pg.py
```

and inspecting the `learner/*/logs/log.csv` output file.