### PR TITLE
Update documentation and fixes Colab badges

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -73,7 +73,7 @@ tfd = tfp.distributions
 
 While custom Sonnet modules can be implemented and used directly, Acme also
 provides a number of useful network primitives which are tailored to RL tasks;
-these can be imported from `acme.networks`, see [networks] for more details.
+these can be imported from `acme.tf.networks`, see [networks] for more details.
 These primitives can be combined using `snt.Sequential`, or `snt.DeepRNN` when
 stacking network modules with state.
 

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -410,4 +410,5 @@
   },
   "nbformat": 4,
   "nbformat_minor": 0
+
 }

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -8,7 +8,8 @@
       },
       "source": [
         "# Acme: Quickstart\n",
-        "# \u003cdiv align=\"left\"\u003e[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepmind/acme/examples/quickstart.ipynb)\u003c/div\u003e\n",
+        "\n",
+        "<a href=\"https://colab.research.google.com/github/deepmind/acme/blob/master/examples/quickstart.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
         "\n",
         "This is a quick guide to installing Acme and a very simple example of running a D4PG agent."
       ]
@@ -80,7 +81,7 @@
         "mujoco_dir = \"$HOME/.mujoco\"\n",
         "\n",
         "# Install OpenGL dependencies\n",
-        "!apt-get update \u0026\u0026 apt-get install -y --no-install-recommends \\\n",
+        "!apt-get update && apt-get install -y --no-install-recommends \\\n",
         "  libgl1-mesa-glx libosmesa6 libglew2.0\n",
         "\n",
         "# Get MuJoCo binaries\n",
@@ -88,7 +89,7 @@
         "!unzip -o -q mujoco.zip -d \"$mujoco_dir\"\n",
         "\n",
         "# Copy over MuJoCo license\n",
-        "!echo \"$mjkey\" \u003e \"$mujoco_dir/mjkey.txt\"\n",
+        "!echo \"$mjkey\" > \"$mujoco_dir/mjkey.txt\"\n",
         "\n",
         "# Install dm_control\n",
         "!pip install dm_control\n",
@@ -365,8 +366,8 @@
         "  # Read video and display the video\n",
         "  video = open(filename, 'rb').read()\n",
         "  b64_video = base64.b64encode(video)\n",
-        "  video_tag = ('\u003cvideo  width=\"320\" height=\"240\" controls alt=\"test\" '\n",
-        "               'src=\"data:video/mp4;base64,{0}\"\u003e').format(b64_video.decode())\n",
+        "  video_tag = ('<video  width=\"320\" height=\"240\" controls alt=\"test\" '\n",
+        "               'src=\"data:video/mp4;base64,{0}\">').format(b64_video.decode())\n",
         "  return IPython.display.HTML(video_tag)"
       ]
     },

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -980,4 +980,5 @@
   },
   "nbformat": 4,
   "nbformat_minor": 0
+
 }

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -9,7 +9,7 @@
       "source": [
         "# Acme: Tutorial\n",
         "\n",
-        "\u003ca href=\"https://colab.research.google.com/github/deepmind/acme/blob/master/examples/tutorial.ipynb\"\u003e\u003cimg src=\"https://colab.research.google.com/assets/colab-badge.svg\"\u003e\u003c/a\u003e\n",
+        "<a href=\"https://colab.research.google.com/github/deepmind/acme/blob/master/examples/tutorial.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
         "\n",
         "This colab provides an overview of how Acme's modules can be stacked together to create reinforcement learning agents. It shows how to fit networks to environment specs, create actors, learners, replay buffers, datasets, adders, and full agents. It also highlights where you can swap out certain modules to create your own Acme based agents. "
       ]
@@ -88,7 +88,7 @@
         "mujoco_dir = \"$HOME/.mujoco\"\n",
         "\n",
         "# Install OpenGL dependencies\n",
-        "!apt-get update \u0026\u0026 apt-get install -y --no-install-recommends \\\n",
+        "!apt-get update && apt-get install -y --no-install-recommends \\\n",
         "  libgl1-mesa-glx libosmesa6 libglew2.0\n",
         "\n",
         "# Get MuJoCo binaries\n",
@@ -96,7 +96,7 @@
         "!unzip -o -q mujoco.zip -d \"$mujoco_dir\"\n",
         "\n",
         "# Copy over MuJoCo license\n",
-        "!echo \"$mjkey\" \u003e \"$mujoco_dir/mjkey.txt\"\n",
+        "!echo \"$mjkey\" > \"$mujoco_dir/mjkey.txt\"\n",
         "\n",
         "# Install dm_control\n",
         "!pip install dm_control\n",
@@ -245,7 +245,7 @@
         "\n",
         "We will later interact with the environment in a loop corresponding to the following diagram: \n",
         "\n",
-        "\u003cimg src=\"https://github.com/deepmind/acme/raw/master/docs/diagrams/environment_loop.png\" width=\"500\" /\u003e\n",
+        "<img src=\"https://github.com/deepmind/acme/raw/master/docs/diagrams/environment_loop.png\" width=\"500\" />\n",
         "\n",
         "But before we start building an agent to interact with this environment, let's first look at the types of objects the environment either returns (e.g. observations) or consumes (e.g. actions). The `environment_spec` will show you the form of the *observations*, *rewards* and *discounts* that the environment exposes and the form of the *actions* that can be taken.\n"
       ]
@@ -327,7 +327,7 @@
         "\n",
         "An `Actor` is the part of our framework that directly interacts with an environment by generating actions. In more detail the earlier diagram can be expanded to show exactly how this interaction occurs:\n",
         "\n",
-        "\u003cimg src=\"https://github.com/deepmind/acme/raw/master/docs/diagrams/actor_loop.png\" width=\"500\" /\u003e\n",
+        "<img src=\"https://github.com/deepmind/acme/raw/master/docs/diagrams/actor_loop.png\" width=\"500\" />\n",
         "\n",
         "While you can always write your own actor, in Acme we also provide a number of useful premade versions. For the network we specified above we will make use of a `FeedForwardActor` that wraps a single feed forward network and knows how to do things like handle any batch dimensions or record observed transitions."
       ]
@@ -401,8 +401,8 @@
         "  # Read video and display the video\n",
         "  video = open(filename, 'rb').read()\n",
         "  b64_video = base64.b64encode(video)\n",
-        "  video_tag = ('\u003cvideo  width=\"320\" height=\"240\" controls alt=\"test\" '\n",
-        "               'src=\"data:video/mp4;base64,{0}\"\u003e').format(b64_video.decode())\n",
+        "  video_tag = ('<video  width=\"320\" height=\"240\" controls alt=\"test\" '\n",
+        "               'src=\"data:video/mp4;base64,{0}\">').format(b64_video.decode())\n",
         "  return IPython.display.HTML(video_tag)"
       ]
     },
@@ -441,7 +441,7 @@
         "\n",
         "Many RL agents utilize a data structure such as a replay buffer to store data from the environment (e.g. observations) along with actions taken by the actor. This data will later be fed into a learning process in order to update the policy. Again we can expand our earlier diagram to include this step:\n",
         "\n",
-        "\u003cimg src=\"https://github.com/deepmind/acme/raw/master/docs/diagrams/batch_loop.png\" width=\"500\" /\u003e\n",
+        "<img src=\"https://github.com/deepmind/acme/raw/master/docs/diagrams/batch_loop.png\" width=\"500\" />\n",
         "\n",
         "In order to make this possible, Acme leverages [Reverb](https://github.com/deepmind/reverb) which is an efficient and easy-to-use data storage and transport system designed for Machine Learning research. Below we will create the replay buffer before interacting with it."
       ]
@@ -774,8 +774,8 @@
         "\n",
         "This is a simple training loop that runs for `num_training_episodes` episodes where the actor and learner take turns generating and learning from experience respectively:\n",
         "\n",
-        "- Actor acts in environment \u0026 adds experience to replay for `min_actor_steps_per_iteration` steps\u003cbr\u003e\n",
-        "- Learner samples from replay data and learns from it for `num_learner_steps_per_iteration` steps\u003cbr\u003e\n",
+        "- Actor acts in environment & adds experience to replay for `min_actor_steps_per_iteration` steps<br>\n",
+        "- Learner samples from replay data and learns from it for `num_learner_steps_per_iteration` steps<br>\n",
         "\n",
         "Note: Since the learner and actor are sharing a policy network, any learning done on the learner, automatically is transferred to the actor's policy.\n"
       ]
@@ -818,7 +818,7 @@
         "    timestep = next_timestep\n",
         "\n",
         "    # See if we have some learning to do.\n",
-        "    if (actor_steps_taken \u003e= min_actor_steps_before_learning and\n",
+        "    if (actor_steps_taken >= min_actor_steps_before_learning and\n",
         "        actor_steps_taken % num_actor_steps_per_iteration == 0):\n",
         "      # Learn.\n",
         "      for learner_step in range(num_learner_steps_per_iteration):\n",
@@ -839,7 +839,7 @@
       "source": [
         "## Putting it all together: an Acme agent\n",
         "\n",
-        "\u003cimg src=\"https://github.com/deepmind/acme/raw/master/docs/diagrams/agent_loop.png\" width=\"500\" /\u003e\n",
+        "<img src=\"https://github.com/deepmind/acme/raw/master/docs/diagrams/agent_loop.png\" width=\"500\" />\n",
         "\n",
         "Now that we've used all of the pieces and seen how they can interact, there's one more way we can put it all together. In the Acme design scheme, an agent is an entity with both a learner and an actor component that will piece together their interactions internally. An agent handles the interchange between actor adding experiences to the replay buffer and learner sampling from it and learning and in turn, sharing its weights back with the actor. \n",
         "\n",


### PR DESCRIPTION
Changes `acme.networks` to `acme.tf.networks` in `components.md` to reflect structure changes, and fixes the Google Colab link in `quickstart.ipynb`. Also makes the Google Colab badges in `quickstart.ipynb` and `tutorial.ipynb` render properly and open immediately upon click.

(I messed up the other PR, so it was just easier to make a new one.  Sorry if this caused any troubles.)