### PR TITLE
R2D2: Cast rewards and discounts to the same type as network values.

### DIFF
--- a/acme/agents/tf/r2d2/learning.py
+++ b/acme/agents/tf/r2d2/learning.py
@@ -153,12 +153,17 @@ class R2D2Learner(acme.Learner, tf2_savers.TFSaveable):
       # Compute the transformed n-step loss.
       rewards = tree.map_structure(lambda x: x[:-1], rewards)
       discounts = tree.map_structure(lambda x: x[:-1], discounts)
+
+      # The rewards and discounts have to have the same type as network values.
+      rewards = tf.cast(rewards, q_values.dtype)
+      discounts = tf.cast(discounts, q_values.dtype) * tf.cast(self._discount, q_values.dtype)
+
       loss, extra = losses.transformed_n_step_loss(
           qs=q_values,
           targnet_qs=target_q_values,
           actions=actions,
           rewards=rewards,
-          pcontinues=discounts * self._discount,
+          pcontinues=discounts,
           target_policy_probs=target_policy_probs,
           bootstrap_n=self._n_step,
       )


### PR DESCRIPTION
Firstly, thanks for open-sourcing this framework!

With respect to this PR, take it as a mere suggestion. Shortly, this PR casts the rewards and discounts in the _step() method of the R2D2 learning module to have the same type as the network type.

I am applying the framework on my own custom environment and I found it a bit tricky due to some precision errors. This happened due to the fact that the dm_env library implicitly creates some values with double precision while (if I understood correctly) the tf networks in ACME support single precision. For example, transition() and termination() implicitly assume double precision:

https://github.com/deepmind/dm_env/blob/bd431e18b6547c76b607bb4685225fb1dfa2da65/dm_env/_environment.py#L232-L239

In my case, I was creating a dm_env.Timestep() via the transition method without explicitly overriding the discount argument, therefore causing a precision error while running the R2D2 agent. But what made me a bit confusing was that this error was not being thrown while running the DQN agent due to the fact that the rewards and discounts are being implicitly cast in the _step method (even though the timesteps were being created the same way for both agents):

https://github.com/deepmind/acme/blob/6aec71bf2ea6f72cedc9b953bfefad89289f06f2/acme/agents/tf/dqn/learning.py#L127-L130

, and this was a bit unpredictable for me. So I just believe that, maybe, one can make the code slightly more consistent by either:
1) not casting on any of the algorithms (remove from the DQN agent)
2) casting on both the algorithms. (What this PR proposes) Probably makes the code a bit more robust (?)

Finally, I do believe this is similarly being done in other algorithms such as dmpo and d4pg.

Once again, thanks!