### PR TITLE
Fix exception cause in video.py

### DIFF
--- a/acme/wrappers/video.py
+++ b/acme/wrappers/video.py
@@ -180,11 +180,11 @@ class MujocoVideoWrapper(VideoWrapper):
     if frame_rate is None:
       try:
         control_timestep = getattr(environment, 'control_timestep')()
-      except AttributeError:
+      except AttributeError as e:
         raise AttributeError('MujocoVideoWrapper expects an environment which '
                              'exposes a control_timestep method, like '
                              'dm_control environments, or frame_rate '
-                             'to be specified.')
+                             'to be specified.') from e
       frame_rate = int(round(playback_speed / control_timestep))
 
     super().__init__(environment, frame_rate=frame_rate, **kwargs)


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. I found one instance of this mistake in the Acme repo, and I fixed it in this PR

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.