### PR TITLE
Change bsuite dependency to point to PyPI package instead of Github repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ jax_requirements = [
 ]
 
 env_requirements = [
-    'bsuite @ git+git://github.com/deepmind/bsuite.git#egg=bsuite',
+    'bsuite',
     'dm-control',
     'gym',
     'gym[atari]',


### PR DESCRIPTION
Fixes bsuite part of issue #98.

To solve the potential similar issue for `rlax` it should be first published to PyPI.