### PR TITLE
Allow truncated sequences in JAX IMPALA.

### DIFF
--- a/acme/agents/jax/impala/agent.py
+++ b/acme/agents/jax/impala/agent.py
@@ -44,6 +44,7 @@ class IMPALAConfig:
   batch_size: int = 16
   sequence_length: int = 20
   sequence_period: int = 20
+  break_end_of_episode: bool = True
   learning_rate: float = 1e-3
   discount: float = 0.99
   entropy_cost: float = 0.01
@@ -178,6 +179,7 @@ class IMPALA(IMPALAFromConfig):
       seed: int = 0,
       max_abs_reward: float = np.inf,
       max_gradient_norm: float = np.inf,
+      break_end_of_episode: bool = True
   ):
 
     forward_fn_transformed = hk.without_apply_rng(hk.transform(
@@ -202,6 +204,7 @@ class IMPALA(IMPALAFromConfig):
         seed=seed,
         max_abs_reward=max_abs_reward,
         max_gradient_norm=max_gradient_norm,
+        break_end_of_episode=break_end_of_episode,
     )
     super().__init__(
         environment_spec=environment_spec,

--- a/acme/agents/jax/impala/learning.py
+++ b/acme/agents/jax/impala/learning.py
@@ -105,6 +105,7 @@ class IMPALALearner(acme.Learner):
       """Initialises the training state (parameters and optimiser state)."""
       dummy_obs = utils.zeros_like(obs_spec)
       dummy_obs = utils.add_batch_dim(dummy_obs)  # Dummy 'sequence' dim.
+      dummy_start_episode = np.array([False])  # Dummy 'sequence' dim.
 
       key, key_initial_state = jax.random.split(key)
       params = initial_state_init_fn(key_initial_state)
@@ -112,7 +113,7 @@ class IMPALALearner(acme.Learner):
       # training the initial state params.
       initial_state = initial_state_fn(params)
 
-      initial_params = unroll_init_fn(key, dummy_obs, initial_state)
+      initial_params = unroll_init_fn(key, dummy_obs, initial_state, dummy_start_episode)
       initial_opt_state = optimizer.init(initial_params)
       return TrainingState(
           params=initial_params, opt_state=initial_opt_state)

--- a/acme/agents/jax/impala/types.py
+++ b/acme/agents/jax/impala/types.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """Some types/assumptions used in the IMPALA agent."""
-from typing import Callable
+from typing import Callable, Optional
 
 from acme.jax import networks
 import haiku as hk
@@ -24,9 +24,9 @@ import jax.numpy as jnp
 # Only simple observations & discrete action spaces for now.
 Observation = jnp.ndarray
 Action = int
-PolicyValueInitFn = Callable[[networks.PRNGKey, Observation, hk.LSTMState],
+PolicyValueInitFn = Callable[[networks.PRNGKey, Observation, hk.LSTMState, Optional[jnp.ndarray]],
                              networks.Params]
-PolicyValueFn = Callable[[networks.Params, Observation, hk.LSTMState],
+PolicyValueFn = Callable[[networks.Params, Observation, hk.LSTMState, Optional[jnp.ndarray]],
                          networks.LSTMOutputs]
 RecurrentStateInitFn = Callable[[networks.PRNGKey], networks.Params]
 RecurrentStateFn = Callable[[networks.Params], hk.LSTMState]

--- a/acme/agents/replay.py
+++ b/acme/agents/replay.py
@@ -90,6 +90,7 @@ def make_reverb_online_queue(
     sequence_length: int,
     sequence_period: int,
     batch_size: int,
+    break_end_of_episode: bool = True,
     replay_table_name: str = adders.DEFAULT_PRIORITY_TABLE,
 ) -> ReverbReplay:
   """Creates a single process queue from an environment spec and extra_spec."""
@@ -107,6 +108,7 @@ def make_reverb_online_queue(
       client=reverb.Client(address),
       period=sequence_period,
       sequence_length=sequence_length,
+      break_end_of_episode=break_end_of_episode
   )
 
   # The dataset object to learn from.


### PR DESCRIPTION
Fixes #42.

This adds support for learning with truncated sequences in
the JAX IMPALA agent. 

Before this commit, the JAX IMPALA agent learns with padded sequences
of fixed length. This commit allows the learning with
truncated sequences, i.e., the sequences will not break and get
padded on episode end. This behaviour is consistent with
other IMPALA imlpementation such as the example IMPALA implementation
in dm-haiku https://github.com/deepmind/dm-haiku/tree/master/examples/impala,
or torchbeast https://github.com/facebookresearch/torchbeast.

Supporting learning with truncated seuqnces without padding
is advantageous in situation where we would like the agent to learn
from environments with sparse rewards, where we typically would like
the agent to learn from reward signals that can only be obtained
from long sequences (e.g., 100), but the optimal behaviour can later
solve the task with much shorter horizon (e.g., 10).

To achieve this, we need to expose the break_end_of_episode in
constructing the SequenceAdder.

Furthermore, the unroll function now takes optional
start_of_epsode argument (for compatibility).
A hk.ResetCore is constrcuted
on the fly to handle resetting of the recurrent state. This requires
no changes to the actor to be aware of the argument since it
already handles the case of resetting the state on episode start.

-------

There are probably better ways to incorporate the behaviour. I am really happy the Acme maintainers can provide some reviews for this if you are interested in adding this functionality. Otherwise, I will keep my own forked version of the IMPALA agent to support this behaviour. 