### PR TITLE
Add optional logger to LocalLayout based agents

### DIFF
--- a/acme/agents/jax/d4pg/agents.py
+++ b/acme/agents/jax/d4pg/agents.py
@@ -117,6 +117,7 @@ class D4PG(local_layout.LocalLayout):
       config: builder.D4PGConfig,
       random_seed: int,
       counter: Optional[counting.Counter] = None,
+      logger: Optional[loggers.Logger] = None,
   ):
     # In the case of a synchronous agent, we do not use Reverb's built-in rate
     # limitation to avoid deadlocks; so rather than using the Builder's min
@@ -131,7 +132,7 @@ class D4PG(local_layout.LocalLayout):
     # This is achieved by setting the rate tolerance to be infinite.
     config.samples_per_insert_tolerance_rate = float('inf')
 
-    self.builder = builder.D4PGBuilder(config)
+    self.builder = builder.D4PGBuilder(config, logger_fn=lambda: logger)
     super().__init__(
         seed=random_seed,
         environment_spec=spec,

--- a/acme/agents/jax/ppo/agents.py
+++ b/acme/agents/jax/ppo/agents.py
@@ -104,8 +104,9 @@ class PPO(local_layout.LocalLayout):
       workdir: Optional[str] = '~/acme',
       normalize_input: bool = False,
       counter: Optional[counting.Counter] = None,
+      logger: Optional[loggers.Logger] = None,
   ):
-    ppo_builder = builder.PPOBuilder(config)
+    ppo_builder = builder.PPOBuilder(config, logger_fn=lambda: logger)
     if normalize_input:
       # Two batch dimensions: [num_sequences, num_steps, ...]
       batch_dims = (0, 1)

--- a/acme/agents/jax/sac/agents.py
+++ b/acme/agents/jax/sac/agents.py
@@ -102,6 +102,7 @@ class SAC(local_layout.LocalLayout):
       seed: int,
       normalize_input: bool = True,
       counter: Optional[counting.Counter] = None,
+      logger: Optional[loggers.Logger] = None,
   ):
     min_replay_size = config.min_replay_size
     # Local layout (actually agent.Agent) makes sure that we populate the
@@ -111,7 +112,7 @@ class SAC(local_layout.LocalLayout):
     # by the following two lines.
     config.samples_per_insert_tolerance_rate = float('inf')
     config.min_replay_size = 1
-    sac_builder = builder.SACBuilder(config)
+    sac_builder = builder.SACBuilder(config, logger_fn=lambda: logger)
     if normalize_input:
       # One batch dimension: [batch_size, ...]
       batch_dims = (0,)

--- a/acme/agents/jax/td3/agents.py
+++ b/acme/agents/jax/td3/agents.py
@@ -98,6 +98,7 @@ class TD3(local_layout.LocalLayout):
       config: td3_config.TD3Config,
       seed: int,
       counter: Optional[counting.Counter] = None,
+      logger: Optional[loggers.Logger] = None,
   ):
     min_replay_size = config.min_replay_size
     # Local layout (actually agent.Agent) makes sure that we populate the
@@ -113,7 +114,7 @@ class TD3(local_layout.LocalLayout):
         action_specs=spec.actions,
         sigma=config.sigma)
 
-    self.builder = builder.TD3Builder(config)
+    self.builder = builder.TD3Builder(config, logger_fn=lambda: logger)
     super().__init__(
         seed=seed,
         environment_spec=spec,

--- a/acme/agents/jax/value_dice/agents.py
+++ b/acme/agents/jax/value_dice/agents.py
@@ -97,6 +97,7 @@ class ValueDice(local_layout.LocalLayout):
       make_demonstrations: Callable[[int], Iterator[types.Transition]],
       seed: int,
       counter: Optional[counting.Counter] = None,
+      logger: Optional[loggers.Logger] = None,
   ):
     min_replay_size = config.min_replay_size
     # Local layout (actually agent.Agent) makes sure that we populate the
@@ -107,7 +108,10 @@ class ValueDice(local_layout.LocalLayout):
     config.samples_per_insert_tolerance_rate = float('inf')
     config.min_replay_size = 1
     self.builder = builder.ValueDiceBuilder(
-        config=config, make_demonstrations=make_demonstrations)
+        config=config,
+        make_demonstrations=make_demonstrations,
+        logger_fn=lambda: logger,
+    )
     super().__init__(
         seed=seed,
         environment_spec=spec,


### PR DESCRIPTION
Add an optional logger parameter to all JAX agents' constructor
that are based on LocalLayout.
This allows the user to customize loggers used by single-process
agents in Acme.