### PR TITLE
Make logger_fn and workdir configurable for LocalLayout agents

### DIFF
--- a/acme/agents/jax/ail/builder.py
+++ b/acme/agents/jax/ail/builder.py
@@ -154,14 +154,16 @@ class AILBuilder(builders.GenericActorLearnerBuilder[ail_networks.AILNetworks,
                  Generic[ail_networks.DirectRLNetworks, DirectPolicyNetwork]):
   """AIL Builder."""
 
-  def __init__(self,
-               rl_agent: builders.GenericActorLearnerBuilder[
-                   ail_networks.DirectRLNetworks, DirectPolicyNetwork,
-                   reverb.ReplaySample],
-               config: ail_config.AILConfig,
-               discriminator_loss: losses.Loss,
-               make_demonstrations: Callable[[int], Iterator[types.Transition]],
-               logger_fn: Callable[[], loggers.Logger] = lambda: None):
+  def __init__(
+      self,
+      rl_agent: builders.GenericActorLearnerBuilder[
+          ail_networks.DirectRLNetworks, DirectPolicyNetwork,
+          reverb.ReplaySample],
+      config: ail_config.AILConfig,
+      discriminator_loss: losses.Loss,
+      make_demonstrations: Callable[[int], Iterator[types.Transition]],
+      logger_fn: Callable[[], Optional[loggers.Logger]] = lambda: None,
+  ):
     """Implements a builder for AIL using rl_agent as forward RL algorithm.
 
     Args:

--- a/acme/agents/jax/d4pg/agents.py
+++ b/acme/agents/jax/d4pg/agents.py
@@ -29,6 +29,7 @@ import dm_env
 
 
 NetworkFactory = Callable[[specs.EnvironmentSpec], builder.D4PGNetworks]
+LoggerFactory = Callable[[], Optional[loggers.Logger]]
 
 
 class DistributedD4PG(distributed_layout.DistributedLayout):
@@ -116,7 +117,9 @@ class D4PG(local_layout.LocalLayout):
       network: builder.D4PGNetworks,
       config: builder.D4PGConfig,
       random_seed: int,
+      workdir: Optional[str] = '~/acme',
       counter: Optional[counting.Counter] = None,
+      logger_fn: LoggerFactory = lambda: None,
   ):
     # In the case of a synchronous agent, we do not use Reverb's built-in rate
     # limitation to avoid deadlocks; so rather than using the Builder's min
@@ -131,7 +134,7 @@ class D4PG(local_layout.LocalLayout):
     # This is achieved by setting the rate tolerance to be infinite.
     config.samples_per_insert_tolerance_rate = float('inf')
 
-    self.builder = builder.D4PGBuilder(config)
+    self.builder = builder.D4PGBuilder(config, logger_fn=logger_fn)
     super().__init__(
         seed=random_seed,
         environment_spec=spec,
@@ -142,5 +145,6 @@ class D4PG(local_layout.LocalLayout):
         samples_per_insert=config.samples_per_insert,
         min_replay_size=min_replay_size,
         num_sgd_steps_per_step=config.num_sgd_steps_per_step,
+        workdir=workdir,
         counter=counter,
     )

--- a/acme/agents/jax/d4pg/builder.py
+++ b/acme/agents/jax/d4pg/builder.py
@@ -98,7 +98,7 @@ class D4PGBuilder(builders.ActorLearnerBuilder):
   def __init__(
       self,
       config: D4PGConfig,
-      logger_fn: Callable[[], loggers.Logger] = lambda: None,
+      logger_fn: Callable[[], Optional[loggers.Logger]] = lambda: None,
   ):
     """Creates a D4PG learner, a behavior policy and an eval actor.
 

--- a/acme/agents/jax/ppo/agents.py
+++ b/acme/agents/jax/ppo/agents.py
@@ -32,6 +32,7 @@ import dm_env
 
 
 NetworkFactory = Callable[[specs.EnvironmentSpec], ppo_networks.PPONetworks]
+LoggerFactory = Callable[[], Optional[loggers.Logger]]
 
 
 class DistributedPPO(distributed_layout.DistributedLayout):
@@ -101,11 +102,12 @@ class PPO(local_layout.LocalLayout):
       networks: ppo_networks.PPONetworks,
       config: ppo_config.PPOConfig,
       seed: int,
-      workdir: Optional[str] = '~/acme',
       normalize_input: bool = False,
+      workdir: Optional[str] = '~/acme',
       counter: Optional[counting.Counter] = None,
+      logger_fn: LoggerFactory = lambda: None,
   ):
-    ppo_builder = builder.PPOBuilder(config)
+    ppo_builder = builder.PPOBuilder(config, logger_fn=logger_fn)
     if normalize_input:
       # Two batch dimensions: [num_sequences, num_steps, ...]
       batch_dims = (0, 1)

--- a/acme/agents/jax/ppo/builder.py
+++ b/acme/agents/jax/ppo/builder.py
@@ -40,7 +40,7 @@ class PPOBuilder(builders.ActorLearnerBuilder):
   def __init__(
       self,
       config: ppo_config.PPOConfig,
-      logger_fn: Callable[[], loggers.Logger] = lambda: None,
+      logger_fn: Callable[[], Optional[loggers.Logger]] = lambda: None,
   ):
     """Creates PPO builder."""
     self._config = config

--- a/acme/agents/jax/sac/agents.py
+++ b/acme/agents/jax/sac/agents.py
@@ -32,6 +32,7 @@ import dm_env
 
 
 NetworkFactory = Callable[[specs.EnvironmentSpec], networks.SACNetworks]
+LoggerFactory = Callable[[], Optional[loggers.Logger]]
 
 
 class DistributedSAC(distributed_layout.DistributedLayout):
@@ -101,7 +102,9 @@ class SAC(local_layout.LocalLayout):
       config: sac_config.SACConfig,
       seed: int,
       normalize_input: bool = True,
+      workdir: Optional[str] = '~/acme',
       counter: Optional[counting.Counter] = None,
+      logger_fn: LoggerFactory = lambda: None,
   ):
     min_replay_size = config.min_replay_size
     # Local layout (actually agent.Agent) makes sure that we populate the
@@ -111,7 +114,7 @@ class SAC(local_layout.LocalLayout):
     # by the following two lines.
     config.samples_per_insert_tolerance_rate = float('inf')
     config.min_replay_size = 1
-    sac_builder = builder.SACBuilder(config)
+    sac_builder = builder.SACBuilder(config, logger_fn=logger_fn)
     if normalize_input:
       # One batch dimension: [batch_size, ...]
       batch_dims = (0,)
@@ -128,5 +131,6 @@ class SAC(local_layout.LocalLayout):
         samples_per_insert=config.samples_per_insert,
         min_replay_size=min_replay_size,
         num_sgd_steps_per_step=config.num_sgd_steps_per_step,
+        workdir=workdir,
         counter=counter,
     )

--- a/acme/agents/jax/sac/builder.py
+++ b/acme/agents/jax/sac/builder.py
@@ -43,7 +43,7 @@ class SACBuilder(builders.ActorLearnerBuilder):
   def __init__(
       self,
       config: sac_config.SACConfig,
-      logger_fn: Callable[[], loggers.Logger] = lambda: None,
+      logger_fn: Callable[[], Optional[loggers.Logger]] = lambda: None,
   ):
     """Creates a SAC learner, a behavior policy and an eval actor.
 

--- a/acme/agents/jax/td3/agents.py
+++ b/acme/agents/jax/td3/agents.py
@@ -31,6 +31,7 @@ import dm_env
 
 
 NetworkFactory = Callable[[specs.EnvironmentSpec], networks.TD3Networks]
+LoggerFactory = Callable[[], Optional[loggers.Logger]]
 
 
 class DistributedTD3(distributed_layout.DistributedLayout):
@@ -97,7 +98,9 @@ class TD3(local_layout.LocalLayout):
       network: networks.TD3Networks,
       config: td3_config.TD3Config,
       seed: int,
+      workdir: Optional[str] = '~/acme',
       counter: Optional[counting.Counter] = None,
+      logger_fn: LoggerFactory = lambda: None,
   ):
     min_replay_size = config.min_replay_size
     # Local layout (actually agent.Agent) makes sure that we populate the
@@ -113,7 +116,7 @@ class TD3(local_layout.LocalLayout):
         action_specs=spec.actions,
         sigma=config.sigma)
 
-    self.builder = builder.TD3Builder(config)
+    self.builder = builder.TD3Builder(config, logger_fn=logger_fn)
     super().__init__(
         seed=seed,
         environment_spec=spec,
@@ -124,5 +127,6 @@ class TD3(local_layout.LocalLayout):
         samples_per_insert=config.samples_per_insert,
         min_replay_size=min_replay_size,
         num_sgd_steps_per_step=config.num_sgd_steps_per_step,
+        workdir=workdir,
         counter=counter,
     )

--- a/acme/agents/jax/td3/builder.py
+++ b/acme/agents/jax/td3/builder.py
@@ -41,7 +41,7 @@ class TD3Builder(builders.ActorLearnerBuilder):
   def __init__(
       self,
       config: td3_config.TD3Config,
-      logger_fn: Callable[[], loggers.Logger] = lambda: None,
+      logger_fn: Callable[[], Optional[loggers.Logger]] = lambda: None,
   ):
     """Creates a TD3 learner, a behavior policy and an eval actor.
 

--- a/acme/agents/jax/value_dice/agents.py
+++ b/acme/agents/jax/value_dice/agents.py
@@ -32,6 +32,7 @@ import dm_env
 
 
 NetworkFactory = Callable[[specs.EnvironmentSpec], networks.ValueDiceNetworks]
+LoggerFactory = Callable[[], Optional[loggers.Logger]]
 
 
 class DistributedValueDice(distributed_layout.DistributedLayout):
@@ -96,7 +97,9 @@ class ValueDice(local_layout.LocalLayout):
       config: value_dice_config.ValueDiceConfig,
       make_demonstrations: Callable[[int], Iterator[types.Transition]],
       seed: int,
+      workdir: Optional[str] = '~/acme',
       counter: Optional[counting.Counter] = None,
+      logger_fn: LoggerFactory = lambda: None,
   ):
     min_replay_size = config.min_replay_size
     # Local layout (actually agent.Agent) makes sure that we populate the
@@ -107,7 +110,9 @@ class ValueDice(local_layout.LocalLayout):
     config.samples_per_insert_tolerance_rate = float('inf')
     config.min_replay_size = 1
     self.builder = builder.ValueDiceBuilder(
-        config=config, make_demonstrations=make_demonstrations)
+        config=config,
+        make_demonstrations=make_demonstrations,
+        logger_fn=logger_fn)
     super().__init__(
         seed=seed,
         environment_spec=spec,
@@ -118,5 +123,6 @@ class ValueDice(local_layout.LocalLayout):
         samples_per_insert=config.samples_per_insert,
         min_replay_size=min_replay_size,
         num_sgd_steps_per_step=config.num_sgd_steps_per_step,
+        workdir=workdir,
         counter=counter,
     )


### PR DESCRIPTION
The constructor of existing local agent classes (AIL, D4PG, PPO, SAC, TD3, ValueDice) do not expose `logger_fn` as a parameter; therefore the default logger will be used. This commit exposes the parameter `logger_fn` and `workdir` to make the logging behavior configurable.