### PR TITLE
Update Reverb dataset

### DIFF
--- a/acme/datasets/reverb.py
+++ b/acme/datasets/reverb.py
@@ -85,7 +85,7 @@ def make_reverb_dataset(
       cycle_length=tf.data.AUTOTUNE,
       num_parallel_calls=num_parallel_calls,
       deterministic=False)
-  
+
   if batch_size:
     dataset = dataset.batch(batch_size, drop_remainder=True)
 

--- a/acme/datasets/reverb.py
+++ b/acme/datasets/reverb.py
@@ -58,7 +58,6 @@ def make_reverb_dataset(
   del convert_zero_size_to_none
   del using_deprecated_adder
   del sequence_length
-  del prefetch_size
 
   # This is the default that used to be set by reverb.TFClient.dataset().
   if max_in_flight_samples_per_worker is None and batch_size is None:
@@ -89,6 +88,9 @@ def make_reverb_dataset(
   if batch_size:
     dataset = dataset.batch(batch_size, drop_remainder=True)
 
+  if prefetch_size:
+    dataset = dataset.prefetch(prefetch_size)
+  
   return dataset
 
 

--- a/acme/datasets/reverb.py
+++ b/acme/datasets/reverb.py
@@ -90,7 +90,7 @@ def make_reverb_dataset(
 
   if prefetch_size:
     dataset = dataset.prefetch(prefetch_size)
-  
+
   return dataset
 
 

--- a/acme/datasets/reverb.py
+++ b/acme/datasets/reverb.py
@@ -59,7 +59,6 @@ def make_reverb_dataset(
   del using_deprecated_adder
   del sequence_length
   del prefetch_size
-  del num_parallel_calls
 
   # This is the default that used to be set by reverb.TFClient.dataset().
   if max_in_flight_samples_per_worker is None and batch_size is None:
@@ -84,9 +83,11 @@ def make_reverb_dataset(
   dataset = tf.data.Dataset.range(1).repeat().interleave(
       map_func=_make_dataset,
       cycle_length=tf.data.AUTOTUNE,
-      num_parallel_calls=tf.data.AUTOTUNE,
+      num_parallel_calls=num_parallel_calls,
       deterministic=False)
-  dataset = dataset.batch(batch_size, drop_remainder=True)
+  
+  if batch_size:
+    dataset = dataset.batch(batch_size, drop_remainder=True)
 
   return dataset
 

--- a/acme/datasets/reverb.py
+++ b/acme/datasets/reverb.py
@@ -30,6 +30,7 @@ def make_reverb_dataset(
     batch_size: Optional[int] = None,
     prefetch_size: Optional[int] = None,
     table: str = adders.DEFAULT_PRIORITY_TABLE,
+    num_parallel_calls: int = 12,
     max_in_flight_samples_per_worker: Optional[int] = None,
     postprocess: Optional[
         Callable[[reverb.ReplaySample], reverb.ReplaySample]] = None,
@@ -57,6 +58,8 @@ def make_reverb_dataset(
   del convert_zero_size_to_none
   del using_deprecated_adder
   del sequence_length
+  del prefetch_size
+  del num_parallel_calls
 
   # This is the default that used to be set by reverb.TFClient.dataset().
   if max_in_flight_samples_per_worker is None and batch_size is None:


### PR DESCRIPTION
Hello,

instead of hardcoding the num_parallel_calls is better to use AUTOTUNE for maximising performance based on machine CPUs. Applied the batching after the interleave rather than before it for maximising performance too. Interleave builds up internal prefetch buffers and doing prefetch more times goes to off policyness.

Based on: https://github.com/deepmind/reverb/issues/90

Thanks.
Have a nice day.