### PR TITLE
fix: Update version of reverb & launchpad to work with distributed ppo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ spec.loader.exec_module(_metadata)
 # sure this constraint is upheld.
 
 tensorflow = [
-    'dm-reverb==0.7.1',
+    'dm-reverb==0.7.2',
     'keras==2.8.0',
     'tensorflow-datasets==4.5.2',
     'tensorflow-estimator==2.8.0',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ tensorflow = [
 core_requirements = [
     'absl-py',
     'dm-env',
-    'dm-launchpad==0.5.1',
+    'dm-launchpad==0.5.2',
     'dm-tree',
     'numpy',
     'pillow',


### PR DESCRIPTION
Package updates to get distributed ppo working (probably other systems too):
- Reverb `v0.7.1` doesn't work with ppo (https://github.com/deepmind/acme/issues/223) due to a change in the rate limiters class. This is fixed in reverb `v0.7.2`.
- Launchpad v0.5.1 doesn't work with the current distributed layout. 

  You get the following error: 
    ```
    program = get_agent_distributed(
    File "/home/kaleab/Documents/Code/dynamic-networks/sparsity_search/agents/single_agent/single_agent.py", line 144, in get_agent_distributed
      program = ppo_jax.make_distributed_ppo(
    File "/home/kaleab/anaconda3/envs/sparsity-rl/lib/python3.9/site-packages/acme/agents/jax/ppo/agents.py", line 83, in make_distributed_ppo
      return distributed_layout.make_distributed_program(
    File "/home/kaleab/anaconda3/envs/sparsity-rl/lib/python3.9/site-packages/acme/jax/layouts/distributed_layout.py", line 346, in make_distributed_program
      replay_node = lp.ReverbNode(
  TypeError: __init__() got an unexpected keyword argument 'checkpoint_time_delta_minutes'
    ```
  
  Lp v0.5.2 has this param and thereby works. 