### PR TITLE
Use num_batch_dims=0 to deal with observations containing scalars

### DIFF
--- a/acme/agents/jax/sac/learning.py
+++ b/acme/agents/jax/sac/learning.py
@@ -208,19 +208,19 @@ class SACLearner(acme.Learner):
       metrics['observations_mean'] = jnp.mean(
           utils.batch_concat(
               jax.tree_map(lambda x: jnp.abs(jnp.mean(x, axis=0)),
-                           transitions.observation)))
+                           transitions.observation), num_batch_dims=0))
       metrics['observations_std'] = jnp.mean(
           utils.batch_concat(
               jax.tree_map(lambda x: jnp.std(x, axis=0),
-                           transitions.observation)))
+                           transitions.observation), num_batch_dims=0))
       metrics['next_observations_mean'] = jnp.mean(
           utils.batch_concat(
               jax.tree_map(lambda x: jnp.abs(jnp.mean(x, axis=0)),
-                           transitions.next_observation)))
+                           transitions.next_observation), num_batch_dims=0))
       metrics['next_observations_std'] = jnp.mean(
           utils.batch_concat(
               jax.tree_map(lambda x: jnp.std(x, axis=0),
-                           transitions.next_observation)))
+                           transitions.next_observation), num_batch_dims=0))
 
       return new_state, metrics
 


### PR DESCRIPTION
When a (nested) observation contain a scalar value on some axes
with dimension 1, batch_concat() will crash due to a shape mismatch
error (e.g., cannot concatenate tensors of shape [100, 1] and []).

This happens because batch_concat by default assumes the input
tensors are batched, but when computing the statistics
the batch dimensions (axis=0) already have been eliminated.
