### PR TITLE
BUGFIX: Unpin tensorflow_datasets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ spec.loader.exec_module(_metadata)
 tensorflow = [
     'dm-reverb==0.7.2',
     'keras==2.8.0',
-    'tensorflow-datasets==4.5.2',
+    'tensorflow-datasets',
     'tensorflow-estimator==2.8.0',
     'tensorflow==2.8.0',
     'tensorflow_probability==0.15.0',


### PR DESCRIPTION
The current pinned version does not work for some of the d4rl locomotion v2 datasets due to the wrong specification in metadata types.