### PR TITLE
Fix the quickstart notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ cython_debug/
 # static files generated from Django application using `collectstatic`
 media
 static
+
+# Examples outputs
+examples/temp.mp4

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "# Acme: Quickstart\n",
         "## Guide to installing Acme and training your first D4PG agent.\n",
-        "# \u003ca href=\"https://colab.research.google.com/github/deepmind/acme/blob/master/examples/quickstart.ipynb\" target=\"_parent\"\u003e\u003cimg src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/\u003e\u003c/a\u003e\n",
+        "# <a href=\"https://colab.research.google.com/github/deepmind/acme/blob/master/examples/quickstart.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
         "\n"
       ]
     },
@@ -23,11 +23,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "xflSXJPS8Qpm"
       },
       "outputs": [],
@@ -62,9 +60,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install dm-acme\n",
-        "!pip install dm-acme[reverb]\n",
-        "!pip install dm-acme[tf]"
+        "!pip install dm-acme[tf,jax]"
       ]
     },
     {
@@ -97,7 +93,7 @@
         "\n",
         "  print('Installing OpenGL dependencies...')\n",
         "  !apt-get update -qq\n",
-        "  !apt-get install -qq -y --no-install-recommends libglew2.0 \u003e /dev/null\n",
+        "  !apt-get install -qq -y --no-install-recommends libglew2.0 > /dev/null\n",
         "\n",
         "  print('Downloading MuJoCo...')\n",
         "  BASE_URL = 'https://github.com/deepmind/mujoco/releases/download'\n",
@@ -121,7 +117,7 @@
         "\n",
         "  print('Installing dm_control...')\n",
         "  # Version 0.0.416848645 is the first one to support MuJoCo 2.1.1.\n",
-        "  !pip install -q dm_control\u003e=0.0.416848645\n",
+        "  !pip install -q dm_control>=0.0.416848645\n",
         "\n",
         "  print('Checking that the dm_control installation succeeded...')\n",
         "  try:\n",
@@ -137,16 +133,15 @@
         "  else:\n",
         "    del suite, env, pixels\n",
         "\n",
-        "  !echo Installed dm_control $(pip show dm_control | grep -Po \"(?\u003c=Version: ).+\")\n",
+        "  !echo Installed dm_control $(pip show dm_control | grep -Po \"(?<=Version: ).+\")\n",
         "\n",
         "elif environment_library == 'gym':\n",
-        "  !pip install gym"
+        "  !pip install gym[classic_control]"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Cl8eyWblSs-z"
       },
       "source": [
@@ -155,16 +150,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "aSM7KHDFSsQS"
       },
       "outputs": [],
       "source": [
         "!sudo apt-get install -y xvfb ffmpeg\n",
-        "!pip install imageio\n",
+        "!pip install imageio[ffmpeg]\n",
         "!pip install PILLOW\n",
         "!pip install pyvirtualdisplay"
       ]
@@ -172,7 +165,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "c-H2d6UZi7Sf"
       },
       "source": [
@@ -181,11 +173,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
         "cellView": "both",
-        "colab": {},
-        "colab_type": "code",
         "id": "HJ74Id-8MERq"
       },
       "outputs": [],
@@ -220,7 +210,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "I6KuVGSk4uc9"
       },
       "source": [
@@ -231,11 +220,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
         "cellView": "both",
-        "colab": {},
-        "colab_type": "code",
         "id": "4PVlHtGF5yzt"
       },
       "outputs": [],
@@ -262,7 +249,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "BukOfOsmtSQn"
       },
       "source": [
@@ -271,10 +257,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "3Jcjk1w6oHVX"
       },
       "outputs": [],
@@ -305,10 +289,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "9CD2sNK-oA9S"
       },
       "outputs": [],
@@ -336,7 +318,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "oKeGQxzitXYC"
       },
       "source": [
@@ -345,10 +326,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "VWZd5N-Qoz82"
       },
       "outputs": [],
@@ -361,7 +340,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Do57Ql4ZsWDu"
       },
       "source": [
@@ -371,7 +349,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "BJXkfg6LSZ-h"
       },
       "source": [
@@ -380,10 +357,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "OIJRbtAlxQVu"
       },
       "outputs": [],
@@ -421,7 +396,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Rh8x46UKSf2c"
       },
       "source": [


### PR DESCRIPTION
Fix the quickstart notebook so that it will work with version 4.1.

 - Remove the Acme extra requirement `reverb` which longer exists, and isn't needed (as `dm-reverb` is installed as part of the TensorFlow extra requirements).
 - Add the Acme extra requirement `jax`, which is required.
 - Add gym's extra `classic_control` dependencies, and Imageio's extra `ffmpeg` dependencies, which are required to render the video.
 - Add the output video file to `.gitignore`.

Note Colab has unfortunately also made some formatting changes to the raw notebook code (replacing html-encoded angle brackets e.g. `\u003ca` with pure `<` brackets, removing some colab metadata, and setting execution count to `null` rather than `0`). Given it does this by default now (and Jupyter Lab does the same) I've left these changes in.

I have checked this with both Colab and Jupyter Lab, and it works on both (successfully training). It is also backwards compatible with v. 4.0 (so it won't break anything if merged now, before 4.1 is released).