### PR TITLE
rewritten jnp.squeeze(self._value_layer(inputs), axis=-1)

### DIFF
--- a/acme/jax/networks/policy_value.py
+++ b/acme/jax/networks/policy_value.py
@@ -24,13 +24,14 @@ class PolicyValueHead(hk.Module):
   """A network with two linear layers, for policy and value respectively."""
 
   def __init__(self, num_actions: int):
-    super().__init__(name='policy_value_network')
+    super().__init__()
     self._policy_layer = hk.Linear(num_actions)
     self._value_layer = hk.Linear(1)
 
   def __call__(self, inputs: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Returns a (Logits, Value) tuple."""
     logits = self._policy_layer(inputs)  # [B, A]
-    value = jnp.squeeze(self._value_layer(inputs), axis=-1)  # [B]
+    value = self._value_layer(inputs)[..., 0]  # [B]
 
     return logits, value
+


### PR DESCRIPTION
jnp.squeeze(self._value_layer(inputs), axis=-1) can be rewritten as self._value_layer(inputs)[..., 0] 
to make the code look more concise.