### PR TITLE
Pinning dm-haiku to 0.0.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ jax_requirements = [
     'jax==0.4.3',
     'jaxlib==0.4.3',
     'chex',
-    'dm-haiku',
+    'dm-haiku==0.0.10',
     'flax',
     'optax',
     'rlax',


### PR DESCRIPTION
I was trying to run the `examples/baselines/rl_continuous/run_sac.py` example and ran into the following issue (trying multiple versions of python3 in clean virtual environments):

```
>>> from acme.agents.jax.d4pg import learning
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/venvs/acme/lib/python3.8/site-packages/acme/agents/jax/d4pg/__init__.py", line 17, in <module>
    from acme.agents.jax.d4pg.builder import D4PGBuilder
  File "/data/venvs/acme/lib/python3.8/site-packages/acme/agents/jax/d4pg/builder.py", line 24, in <module>
    from acme.agents.jax import actor_core as actor_core_lib
  File "/data/venvs/acme/lib/python3.8/site-packages/acme/agents/jax/actor_core.py", line 21, in <module>
    from acme.jax import networks as networks_lib
  File "/data/venvs/acme/lib/python3.8/site-packages/acme/jax/networks/__init__.py", line 17, in <module>
    from acme.jax.networks.atari import AtariTorso
  File "/data/venvs/acme/lib/python3.8/site-packages/acme/jax/networks/atari.py", line 27, in <module>
    from acme.jax.networks import base
  File "/data/venvs/acme/lib/python3.8/site-packages/acme/jax/networks/base.py", line 23, in <module>
    from acme.jax import utils as jax_utils
  File "/data/venvs/acme/lib/python3.8/site-packages/acme/jax/utils.py", line 27, in <module>
    import haiku as hk
  File "/data/venvs/acme/lib/python3.8/site-packages/haiku/__init__.py", line 19, in <module>
    from haiku import data_structures
  File "/data/venvs/acme/lib/python3.8/site-packages/haiku/data_structures.py", line 18, in <module>
    from haiku._src.data_structures import to_haiku_dict
  File "/data/venvs/acme/lib/python3.8/site-packages/haiku/_src/data_structures.py", line 30, in <module>
    from haiku._src import utils
  File "/data/venvs/acme/lib/python3.8/site-packages/haiku/_src/utils.py", line 42, in <module>
    def auto_repr(cls: type[Any], *args, **kwargs) -> str:
TypeError: 'type' object is not subscriptable
```

The same issue seems to exist in the [Acme quickstart](https://colab.research.google.com/github/deepmind/acme/blob/master/examples/quickstart.ipynb) Colab notebook as well. In both cases, I was able to fix it by pinning `dm-haiku==0.0.10`. `dm-haiku 0.0.11` has been released a couple of days ago so I guess it would be better to pin to `0.0.10` for now so that new users are able to run the examples and the Colab notebook.