### PR TITLE
Fixes #347: Pin JAX/Chex dependencies in Colab notebooks

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -41,6 +41,8 @@
       },
       "outputs": [],
       "source": [
+        "# Fix for issue #347: Pin compatible dependency versions\n",
+        "%pip install jax>=0.4.13 jaxlib>=0.4.13 chex==0.1.7\n",
         "%pip install git+https://github.com/deepmind/acme.git#egg=dm-acme[jax,tf,envs]"
       ]
     },

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -39,6 +39,8 @@
       },
       "outputs": [],
       "source": [
+        "# Fix for issue #347: Pin compatible dependency versions\n",
+        "%pip install jax>=0.4.13 jaxlib>=0.4.13 chex==0.1.7\n",
         "%pip install git+https://github.com/deepmind/acme.git#egg=dm-acme[jax,tf,envs]"
       ]
     },


### PR DESCRIPTION
The quickstart and tutorial notebooks fail to run in Google Colab due to dependency version mismatches with JAX and Chex libraries.

This fix pins compatible versions before installing dm-acme:
- jax>=0.4.13
- jaxlib>=0.4.13
- chex==0.1.7

Closes #347