### PR TITLE
Fix ImportError: Cannot import experiments from acme.jax

### DIFF
--- a/acme/jax/__init__.py
+++ b/acme/jax/__init__.py
@@ -12,3 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""JAX-specific components for Acme."""
+
+# Expose the experiments submodule.
+from acme.jax import experiments


### PR DESCRIPTION
## Summary
Fixes #335 

The `experiments` submodule was not exposed in `acme/jax/__init__.py`, causing `from acme.jax import experiments` to fail with an `ImportError` when users install Acme via pip.

## Problem
Users following the [quickstart tutorial](https://colab.research.google.com/github/deepmind/acme/blob/master/examples/quickstart.ipynb) encounter this error:

```python
from acme.jax import experiments
# ImportError: cannot import name 'experiments' from 'acme.jax'
```

## Root Cause
The `acme/jax/experiments/` submodule exists with a proper `__init__.py` that exports all necessary classes (`ExperimentConfig`, `run_experiment`, etc.). However, the parent module `acme/jax/__init__.py` was empty and didn't expose the `experiments` submodule.

## Solution
Added the missing import statement to `acme/jax/__init__.py`:

```python
"""JAX-specific components for Acme."""

# Expose the experiments submodule.
from acme.jax import experiments
```

## Impact
This import pattern is used in:
- The quickstart tutorial (`examples/quickstart.ipynb`)
- All baseline example scripts (rl_continuous, rl_discrete, imitation)
- 21+ files throughout the codebase

## Testing
- Verified syntax is valid with `python3 -m py_compile`
- The fix follows the same pattern used in `acme/__init__.py` for exposing submodules
