### PR TITLE
Support nested observation structures in MCTS agent

### DIFF
--- a/acme/agents/tf/mcts/acting.py
+++ b/acme/agents/tf/mcts/acting.py
@@ -22,6 +22,7 @@ from acme import specs
 from acme.agents.tf.mcts import models
 from acme.agents.tf.mcts import search
 from acme.agents.tf.mcts import types
+from acme.tf import utils as tf2_utils
 from acme.tf import variable_utils as tf2_variable_utils
 
 import dm_env
@@ -66,7 +67,9 @@ class MCTSActor(acme.Actor):
   def _forward(
       self, observation: types.Observation) -> Tuple[types.Probs, types.Value]:
     """Performs a forward pass of the policy-value network."""
-    logits, value = self._network(tf.expand_dims(observation, axis=0))
+    # Use tree.map_structure to support nested observation structures.
+    batched_observation = tf2_utils.add_batch_dim(observation)
+    logits, value = self._network(batched_observation)
 
     # Convert to numpy & take softmax.
     logits = logits.numpy().squeeze(axis=0)

--- a/acme/agents/tf/mcts/types.py
+++ b/acme/agents/tf/mcts/types.py
@@ -14,7 +14,7 @@
 
 """Type aliases and assumptions that are specific to the MCTS agent."""
 
-from typing import Callable, Tuple, Union
+from typing import Any, Callable, Tuple, Union
 import numpy as np
 
 # pylint: disable=invalid-name
@@ -22,8 +22,9 @@ import numpy as np
 # Assumption: actions are scalar and discrete (integral).
 Action = Union[int, np.int32, np.int64]
 
-# Assumption: observations are array-like.
-Observation = np.ndarray
+# Observations can be array-like or nested structures (e.g., dicts, tuples).
+# This allows MCTS to work with environments that have complex observation spaces.
+Observation = Any
 
 # Assumption: rewards and discounts are scalar.
 Reward = Union[float, np.float32, np.float64]


### PR DESCRIPTION
## Summary
Fixes #341 

The `MCTSActor._forward()` method previously hard-coded `tf.expand_dims()` directly on the observation, which only works for array-like observations (`np.ndarray`). This prevented using nested structures (dicts, tuples) as observations.

## Problem
As described in #341, when passing nested observation structures to the MCTS agent:

```python
# This fails with nested observations
logits, value = self._network(tf.expand_dims(observation, axis=0))
```

The `tf.expand_dims` call assumes the observation is a single array, but many environments use nested observation spaces (dictionaries, tuples, etc.).

## Solution
Modified `acme/agents/tf/mcts/acting.py` to use the existing `tf2_utils.add_batch_dim()` utility, which internally uses `tree.map_structure()` to apply `tf.expand_dims` to each leaf of the observation structure:

```python
from acme.tf import utils as tf2_utils
# ...
batched_observation = tf2_utils.add_batch_dim(observation)
logits, value = self._network(batched_observation)
```

Also updated `acme/agents/tf/mcts/types.py` to change the `Observation` type from `np.ndarray` to `Any` to properly reflect that nested structures are now supported.

## Changes
- `acme/agents/tf/mcts/acting.py`: Use `tf2_utils.add_batch_dim()` instead of direct `tf.expand_dims()`
- `acme/agents/tf/mcts/types.py`: Update `Observation` type alias to `Any`

## Testing
- Verified syntax is valid with `python3 -m py_compile`
- The fix follows the existing pattern used in `acme/tf/utils.py` (see `add_batch_dim` function, line 28-30)
