### PR TITLE
fix: use launch_with_termination_handler for clean experiment termina…

### DIFF
--- a/examples/baselines/imitation/run_bc.py
+++ b/examples/baselines/imitation/run_bc.py
@@ -183,7 +183,8 @@ def main(_):
   config = build_experiment_config()
   if FLAGS.run_distributed:
     program = experiments.make_distributed_offline_experiment(experiment=config)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_offline_experiment(
         experiment=config,

--- a/examples/baselines/imitation/run_gail.py
+++ b/examples/baselines/imitation/run_gail.py
@@ -142,7 +142,8 @@ def main(_):
   if FLAGS.run_distributed:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/imitation/run_iqlearn.py
+++ b/examples/baselines/imitation/run_iqlearn.py
@@ -133,7 +133,8 @@ def main(_):
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4
     )
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/imitation/run_pwil.py
+++ b/examples/baselines/imitation/run_pwil.py
@@ -148,7 +148,8 @@ def main(_):
   if FLAGS.run_distributed:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/imitation/run_sqil.py
+++ b/examples/baselines/imitation/run_sqil.py
@@ -92,7 +92,8 @@ def main(_):
   if FLAGS.run_distributed:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/rl_continuous/run_d4pg.py
+++ b/examples/baselines/rl_continuous/run_d4pg.py
@@ -73,7 +73,8 @@ def main(_):
   if FLAGS.run_distributed:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/rl_continuous/run_dmpo.py
+++ b/examples/baselines/rl_continuous/run_dmpo.py
@@ -87,7 +87,8 @@ def main(_):
   if RUN_DISTRIBUTED.value:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/rl_continuous/run_mogmpo.py
+++ b/examples/baselines/rl_continuous/run_mogmpo.py
@@ -79,7 +79,8 @@ def main(_):
   if RUN_DISTRIBUTED.value:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/rl_continuous/run_mpo.py
+++ b/examples/baselines/rl_continuous/run_mpo.py
@@ -79,7 +79,8 @@ def main(_):
   if RUN_DISTRIBUTED.value:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/rl_continuous/run_ppo.py
+++ b/examples/baselines/rl_continuous/run_ppo.py
@@ -61,7 +61,8 @@ def main(_):
   if FLAGS.run_distributed:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=FLAGS.num_distributed_actors)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/rl_continuous/run_sac.py
+++ b/examples/baselines/rl_continuous/run_sac.py
@@ -69,7 +69,8 @@ def main(_):
   if FLAGS.run_distributed:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/rl_continuous/run_td3.py
+++ b/examples/baselines/rl_continuous/run_td3.py
@@ -64,7 +64,8 @@ def main(_):
   if FLAGS.run_distributed:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/rl_continuous/run_wpo.py
+++ b/examples/baselines/rl_continuous/run_wpo.py
@@ -77,7 +77,8 @@ def main(_):
   if RUN_DISTRIBUTED.value:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config,

--- a/examples/baselines/rl_discrete/run_dqn.py
+++ b/examples/baselines/rl_discrete/run_dqn.py
@@ -74,7 +74,8 @@ def main(_):
     program = experiments.make_distributed_experiment(
         experiment=experiment_config,
         num_actors=4 if lp_utils.is_local_run() else 128)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(experiment_config)
 

--- a/examples/baselines/rl_discrete/run_impala.py
+++ b/examples/baselines/rl_discrete/run_impala.py
@@ -79,7 +79,8 @@ def main(_):
     program = experiments.make_distributed_experiment(
         experiment=experiment_config,
         num_actors=4 if lp_utils.is_local_run() else 256)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(experiment_config)
 

--- a/examples/baselines/rl_discrete/run_mdqn.py
+++ b/examples/baselines/rl_discrete/run_mdqn.py
@@ -75,7 +75,8 @@ def main(_):
     program = experiments.make_distributed_experiment(
         experiment=experiment_config,
         num_actors=4 if lp_utils.is_local_run() else 128)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(experiment_config)
 

--- a/examples/baselines/rl_discrete/run_muzero.py
+++ b/examples/baselines/rl_discrete/run_muzero.py
@@ -122,7 +122,8 @@ def main(_):
       num_inference_servers=num_inference_servers,
       inference_server_config=inference_server_config,
   )
-  lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program,),)
+  lp_utils.launch_with_termination_handler(
+      program, xm_resources=lp_utils.make_xm_docker_resources(program))
 
 
 if __name__ == '__main__':

--- a/examples/baselines/rl_discrete/run_qr_dqn.py
+++ b/examples/baselines/rl_discrete/run_qr_dqn.py
@@ -79,7 +79,8 @@ def main(_):
     program = experiments.make_distributed_experiment(
         experiment=experiment_config,
         num_actors=4 if lp_utils.is_local_run() else 16)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(experiment_config)
 

--- a/examples/baselines/rl_discrete/run_r2d2.py
+++ b/examples/baselines/rl_discrete/run_r2d2.py
@@ -84,7 +84,8 @@ def main(_):
   if FLAGS.run_distributed:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4 if lp_utils.is_local_run() else 80)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(experiment=config)
 

--- a/examples/multiagent/multigrid/run_multigrid.py
+++ b/examples/multiagent/multigrid/run_multigrid.py
@@ -101,7 +101,8 @@ def main(_):
   if _RUN_DISTRIBUTED.value:
     program = experiments.make_distributed_experiment(
         experiment=config, num_actors=4)
-    lp.launch(program, xm_resources=lp_utils.make_xm_docker_resources(program))
+    lp_utils.launch_with_termination_handler(
+        program, xm_resources=lp_utils.make_xm_docker_resources(program))
   else:
     experiments.run_experiment(
         experiment=config, eval_every=_EVAL_EVERY.value, num_eval_episodes=5)


### PR DESCRIPTION
…tion

This PR addresses issue #312 by updating all example scripts to use lp_utils.launch_with_termination_handler() instead of lp.launch() directly.

The launch_with_termination_handler() function wraps lp.launch() with a signal handler that ensures all Launchpad processes are properly terminated when the parent process receives a SIGTERM or SIGINT signal. This prevents the messy teardown messages like:
  'Worker groups that did not terminate in time: ['actor'] Killing entire runtime.'

This is especially important when using external loggers like Weights and Biases, which previously reported experiments as 'crashed' even though they completed successfully.

Files updated:
- examples/baselines/imitation/*.py
- examples/baselines/rl_continuous/*.py
- examples/baselines/rl_discrete/*.py
- examples/multiagent/multigrid/run_multigrid.py

Fixes #312