### PR TITLE
docs: Clarify installation instructions for running examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ in our [technical report][Paper].
 
 ## Installation
 
+> ⚠️ **Important Note**: The PyPI package (`dm-acme`) may be significantly out of
+> date compared to this repository. If you want to run the examples or use the
+> latest agents, we strongly recommend **installing from source** (see option 2
+> below).
+
 To get up and running quickly just follow the steps below:
 
 1.  While you can install Acme in your standard python environment, we
@@ -63,31 +68,41 @@ To get up and running quickly just follow the steps below:
     pip install --upgrade pip setuptools wheel
     ```
 
-1.  While the core `dm-acme` library can be pip installed directly, the set of
+2.  **Recommended: Installing from source** (required for running examples):
+
+    The examples in this repository require the latest code which may not be
+    available in the PyPI package. Install from source by cloning this repository:
+
+    ```bash
+    git clone https://github.com/google-deepmind/acme.git
+    cd acme
+    pip install -e .[jax,tf,envs]
+    ```
+
+    This installs Acme in "editable" mode, allowing you to run all examples and
+    use the latest agents.
+
+3.  **Alternative: Installing from PyPI** (may be outdated):
+
+    While the core `dm-acme` library can be pip installed directly, the set of
     dependencies included for installation is minimal. In particular, to run any
     of the included agents you will also need either [JAX] or [TensorFlow]
-    depending on the agent. As a result we recommend installing these components
-    as well, i.e.
+    depending on the agent:
 
     ```bash
     pip install dm-acme[jax,tf]
     ```
 
-1.  Finally, to install a few example environments (including [gym],
-    [dm_control], and [bsuite]):
+    To install a few example environments (including [gym], [dm_control], and
+    [bsuite]):
 
     ```bash
     pip install dm-acme[envs]
     ```
 
-1.  **Installing from github**: if you're interested in running the
-    bleeding-edge version of Acme, you can do so by cloning the Acme GitHub
-    repository and then executing following command from the main directory
-    (where `setup.py` is located):
-
-    ```bash
-    pip install .[jax,tf,testing,envs]
-    ```
+    > Note: If you encounter import errors when running examples after pip
+    > install (e.g., `cannot import name 'sac' from 'acme.agents.jax'`), please
+    > install from source using option 2 above.
 
 ## Citing Acme
 


### PR DESCRIPTION
## Summary
This PR addresses issue #297 by updating the README installation instructions to help users avoid import errors when running examples.

## Problem
Users who install `dm-acme` via pip and try to run the examples encounter import errors like:
```
cannot import name 'sac' from 'acme.agents.jax'
```

This happens because the PyPI package was last updated in **February 2022**, while the GitHub repository has continued to evolve with new agents and features.

## Solution
Updated the README.md to:
1. Add a prominent warning that the PyPI package may be outdated
2. Recommend installing from source as the **primary method** for running examples
3. Reorganize installation steps to emphasize source installation first
4. Add troubleshooting note for users who encounter import errors after pip install

## Changes
- `README.md`: Reorganized installation section with clearer guidance

Fixes #297This PR addresses issue #297 by updating the README to:

1. Add a prominent warning that the PyPI package may be outdated
2. Recommend installing from source as the primary method for running examples
3. Reorganize installation steps to emphasize source installation
4. Add troubleshooting note for import errors after pip install

The PyPI package (dm-acme) was last updated in February 2022, while the GitHub repository has continued to evolve with new agents and features. This mismatch causes import errors when users try to run the examples after installing via pip.

Fixes #297