### PR TITLE
Fix typo in end_of_episode_behavior error messages

### DIFF
--- a/acme/adders/reverb/sequence.py
+++ b/acme/adders/reverb/sequence.py
@@ -163,7 +163,7 @@ class SequenceAdder(base.ReverbAdder):
     elif isinstance(end_of_episode_behavior, EndBehavior):
       self._end_of_episode_behavior = end_of_episode_behavior
     else:
-      raise ValueError('end_of_episod_behavior must be an instance of '
+      raise ValueError('end_of_episode_behavior must be an instance of '
                        f'EndBehavior, received {end_of_episode_behavior}.')
 
   def reset(self):  # pytype: disable=signature-mismatch  # overriding-parameter-count-checks

--- a/acme/adders/reverb/structured.py
+++ b/acme/adders/reverb/structured.py
@@ -254,7 +254,7 @@ def create_sequence_config(
 
   Raises:
     ValueError: If sequence_length is <= 0.
-    NotImplementedError: If `end_of_episod_behavior` is `ZERO_PAD`.
+    NotImplementedError: If `end_of_episode_behavior` is `ZERO_PAD`.
   """
   if sequence_length <= 0:
     raise ValueError(f'sequence_length must be > 0 but got {sequence_length}.')
@@ -359,7 +359,7 @@ def create_sequence_config(
       end_of_episode_configs.append(config)
   else:
     raise ValueError(
-        f'Unexpected `end_of_episod_behavior`: {end_of_episode_behavior}'
+        f'Unexpected `end_of_episode_behavior`: {end_of_episode_behavior}'
     )
 
   return [base_config] + end_of_episode_configs


### PR DESCRIPTION
The parameter name end_of_episode_behavior was misspelled as end_of_episod_behavior (missing the final 'e') in three error message strings across two files.

- acme/adders/reverb/sequence.py: ValueError when end_of_episode_behavior is not an EndBehavior instance
- acme/adders/reverb/structured.py: docstring Raises entry for create_sequence_config, and the ValueError for unexpected enum values

These show up directly in tracebacks so the inconsistency between the parameter name and the error text is confusing.